### PR TITLE
Update appstream.patch to denote updated Flatpak version

### DIFF
--- a/appstream.patch
+++ b/appstream.patch
@@ -51,7 +51,7 @@ index c39cd299..9170ce2a 100644
    <update_contact>paul@zerobrane.com</update_contact>
 -</application>
 +  <releases>
-+    <release version="1.90" date="2020-02-09"/>
++    <release version="2.01" date="2023-09-26"/>
 +  </releases>
 +</component>
 -- 


### PR DESCRIPTION
Because Flathub still shows the Flatpak version as being 1.90 instead of 2.01 even after the version update.

I forgot to handle this in https://github.com/flathub/com.zerobrane.studio/pull/6 :man_facepalming: 